### PR TITLE
chore: temporarily increase dependabot pr limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,12 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    open-pull-requests-limit: 20
     schedule:
       interval: monthly
 
   - package-ecosystem: npm
     directory: /
+    open-pull-requests-limit: 20
     schedule:
       interval: monthly


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Dependabot says it can't open any more pull requests. However, there's a bit of a backlog of out of date PRs, so let's bump this limit up for a bit so we can get all our dependabot PRs created

